### PR TITLE
Lower FSharp.Core requirement & Remove Fable.Elmish dependency

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta-2
+* Lower FSharp.Core requirement
+* Remove Fable.Elmish dependency
+
 ## 1.0.0-beta-1
 * Move to .NET 6 SDK, netstandard2.1 target as the minimum
 

--- a/src/Fable.Elmish.UrlParser.fsproj
+++ b/src/Fable.Elmish.UrlParser.fsproj
@@ -7,7 +7,7 @@
     <Compile Include="parser.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Elmish" Version="4.0.0-beta-*" />
+    <PackageReference Update="FSharp.Core" Version="4.7.*" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="*.fsproj; *.fs" PackagePath="fable\" />


### PR DESCRIPTION
Hello @et1975,

while working on making [Fulma use the new package Fable.React.Types](https://github.com/Fulma/Fulma/pull/315 ) I discovered that some of Elmish packages depends on FSharp.Core 6.x.

But in general, we try to make the dependency on FSharp.Core as low as possible to let the user control it as they want.

We need to fix Fable.Elmish.Browser but first we need to fix this project urlParser.

I don't have ownership over urlParser on NuGet so I can't push a new version. Can you please push it or make me an owner please?